### PR TITLE
修复PC端手杀UI开局换牌、弃牌提示的bug

### DIFF
--- a/shoushaUI/lbtn/main1_window.css
+++ b/shoushaUI/lbtn/main1_window.css
@@ -225,7 +225,9 @@
 	overflow: visible;
 	transition: none;
 }
-.control > div.primary {
+.control>div.primary,
+.control>div.qi,
+.control>div.huan {
 	--p: calc(var(--h) * 11 / 75);
 	background-image: none;
 }
@@ -286,6 +288,12 @@
 	display: none;
 }
 
+.control>div.qi>span {
+	background-image: url("./images/uibutton/qipai.png");
+}
+.control>div.huan>span {
+	background-image: url("./images/uibutton/huanpai.png");
+}
 /*手牌*/
 /*这里给这个元素设置了一些默认值，如果在这个标签下的元素，不再设置其他值时，将调用这些默认值*/
 .handcardNumber {


### PR DESCRIPTION
如图
![Snipaste_2024-11-27_23-22-44](https://github.com/user-attachments/assets/78fd3d54-e9f0-4cad-aea3-45b3c36df011)
![Snipaste_2024-11-27_23-23-11](https://github.com/user-attachments/assets/9a0ed4b7-a0b7-4c18-a8f0-9acb9e3a186c)
修复后
![image](https://github.com/user-attachments/assets/66a24388-69bf-40fb-8390-3dd5d7611e66)
![image](https://github.com/user-attachments/assets/d34b786a-d091-429d-944d-f3bc8e21920b)
