### PR TITLE
修复一将成名样式显示千幻皮肤名的一个bug

### DIFF
--- a/shoushaUI/character/main3.js
+++ b/shoushaUI/character/main3.js
@@ -106,17 +106,13 @@ app.import(function (lib, game, ui, get, ai, _status, app) {
 							let value = "";
 							let value2, value3;
 							if (lib.config["extension_千幻聆音_enable"]) {
-								value2 = game.qhly_getSkin(name);
-								if (value2) value2 = value2.substring(0, value2.lastIndexOf("."));
-								else value2 = "经典形象";
+								value2 = game.qhly_getSkin(name) ? game.qhly_getSkinInfo(name, game.qhly_getSkin(name), null).translation : "经典形象";
 							} else value2 = "经典形象";
 							value += value2 + "*" + get.translation(name);
 							if (name2) {
 								value += "<br>";
 								if (lib.config["extension_千幻聆音_enable"]) {
-									value3 = game.qhly_getSkin(name2);
-									if (value3) value3 = value3.substring(0, value3.lastIndexOf("."));
-									else value3 = "经典形象";
+									value3 = game.qhly_getSkin(name2) ? game.qhly_getSkinInfo(name2, game.qhly_getSkin(name2), null).translation : "经典形象";
 								} else value3 = "经典形象";
 								value += value3 + "*" + get.translation(name2);
 							}

--- a/shoushaUI/character/main3.js
+++ b/shoushaUI/character/main3.js
@@ -106,13 +106,13 @@ app.import(function (lib, game, ui, get, ai, _status, app) {
 							let value = "";
 							let value2, value3;
 							if (lib.config["extension_千幻聆音_enable"]) {
-								value2 = game.qhly_getSkin(name) ? game.qhly_getSkinInfo(name, game.qhly_getSkin(name), null).translation : "经典形象";
+								value2 = game.qhly_getSkinInfo(name, game.qhly_getSkin(name), null).translation || "经典形象";
 							} else value2 = "经典形象";
 							value += value2 + "*" + get.translation(name);
 							if (name2) {
 								value += "<br>";
 								if (lib.config["extension_千幻聆音_enable"]) {
-									value3 = game.qhly_getSkin(name2) ? game.qhly_getSkinInfo(name2, game.qhly_getSkin(name2), null).translation : "经典形象";
+									value3 = game.qhly_getSkinInfo(name2, game.qhly_getSkin(name2), null).translation || "经典形象";
 								} else value3 = "经典形象";
 								value += value3 + "*" + get.translation(name2);
 							}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/54160be6-9d5b-42b6-b55b-0e8393fbed5b)

如图，用一将成名样式玩阳光包孙寒华时发现显示皮肤名实际是对应路径的文件名而非皮肤名翻译；
![image](https://github.com/user-attachments/assets/bf73b64e-133a-43de-962a-a1ca33a51852)
修复后